### PR TITLE
feat(knn): add approximate nearest neighbor search with USearch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+env:
+  RUSTFLAGS: "-C target-cpu=native"
+  CARGO_TERM_COLOR: always
+
 jobs:
   title:
     runs-on: ubuntu-latest
@@ -18,10 +22,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Install BLAS
+      - name: Add Ubuntu Toolchain PPA
+        run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+          sudo apt-get update -yq
+
+      - name: Install GCC 13 and BLAS
         uses: Eeems-Org/apt-cache-action@v1
         with:
-          packages: libopenblas-dev
+          packages: gcc-13 g++-13 libopenblas-dev
+
+      - name: Set GCC 13 as default
+        run: |
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 60 \
+            --slave /usr/bin/g++ g++ /usr/bin/g++-13 \
+            --slave /usr/bin/gcov gcov /usr/bin/gcov-13
+          export CC=/usr/bin/gcc-13
+          export CXX=/usr/bin/g++-13
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -49,10 +66,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Install BLAS
+      - name: Add Ubuntu Toolchain PPA
+        run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+          sudo apt-get update -yq
+
+      - name: Install GCC 13 and BLAS
         uses: Eeems-Org/apt-cache-action@v1
         with:
-          packages: libopenblas-dev
+          packages: gcc-13 g++-13 libopenblas-dev
+
+      - name: Set GCC 13 as default
+        run: |
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 60 \
+            --slave /usr/bin/g++ g++ /usr/bin/g++-13 \
+            --slave /usr/bin/gcov gcov /usr/bin/gcov-13
+          export CC=/usr/bin/gcc-13
+          export CXX=/usr/bin/g++-13
 
       - name: Checkout code
         uses: actions/checkout@v4
@@ -74,10 +104,23 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Install BLAS
+      - name: Add Ubuntu Toolchain PPA
+        run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+          sudo apt-get update -yq
+
+      - name: Install GCC 13 and BLAS
         uses: Eeems-Org/apt-cache-action@v1
         with:
-          packages: libopenblas-dev
+          packages: gcc-13 g++-13 libopenblas-dev
+
+      - name: Set GCC 13 as default
+        run: |
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 60 \
+            --slave /usr/bin/g++ g++ /usr/bin/g++-13 \
+            --slave /usr/bin/gcov gcov /usr/bin/gcov-13
+          export CC=/usr/bin/gcc-13
+          export CXX=/usr/bin/g++-13
 
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,24 @@ jobs:
       contents: read
 
     steps:
+      - name: Add Ubuntu Toolchain PPA
+        run: |
+          sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
+          sudo apt-get update -yq
+
+      - name: Install GCC 13 and BLAS
+        uses: Eeems-Org/apt-cache-action@v1
+        with:
+          packages: gcc-13 g++-13 libopenblas-dev
+
+      - name: Set GCC 13 as default
+        run: |
+          sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 60 \
+            --slave /usr/bin/g++ g++ /usr/bin/g++-13 \
+            --slave /usr/bin/gcov gcov /usr/bin/gcov-13
+          export CC=/usr/bin/gcc-13
+          export CXX=/usr/bin/g++-13
+
       - uses: actions/checkout@v4
 
       - name: Set up Rust toolchain

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,10 +33,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.92"
+name = "anes"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74f37166d7d48a0284b99dd824694c26119c700b53bf0d1540cdb147dbdaaf13"
+checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anyhow"
+version = "1.0.93"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 
 [[package]]
 name = "approx"
@@ -122,6 +134,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
+name = "cast"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
+
+[[package]]
 name = "cblas-sys"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,9 +150,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.34"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b9470d453346108f93a59222a9a1a5724db32d0a4727b7ab7ace4b4d822dc9"
+checksum = "1aeb932158bd710538c73702db6945cb68a8fb08c519e6e12706b94263b36db8"
 dependencies = [
  "shlex",
 ]
@@ -160,12 +178,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "ciborium"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
+dependencies = [
+ "ciborium-io",
+ "ciborium-ll",
+ "serde",
+]
+
+[[package]]
+name = "ciborium-io"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
+
+[[package]]
+name = "ciborium-ll"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
+dependencies = [
+ "ciborium-io",
+ "half",
+]
+
+[[package]]
+name = "clap"
+version = "4.5.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97f376d85a664d5837dbae44bf546e6477a679ff6610010f17276f686d867e8"
+dependencies = [
+ "clap_builder",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19bc80abd44e4bed93ca373a0704ccbd1b710dc5749406201bb018272808dc54"
+dependencies = [
+ "anstyle",
+ "clap_lex",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
+
+[[package]]
 name = "cmake"
 version = "0.1.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a"
 dependencies = [
  "cc",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
+dependencies = [
+ "termcolor",
+ "unicode-width",
 ]
 
 [[package]]
@@ -186,9 +266,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+checksum = "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
 dependencies = [
  "libc",
 ]
@@ -200,6 +280,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "criterion"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
+dependencies = [
+ "anes",
+ "cast",
+ "ciborium",
+ "clap",
+ "criterion-plot",
+ "is-terminal",
+ "itertools 0.10.5",
+ "num-traits",
+ "once_cell",
+ "oorandom",
+ "plotters",
+ "rayon",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "tinytemplate",
+ "walkdir",
+]
+
+[[package]]
+name = "criterion-plot"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
+dependencies = [
+ "cast",
+ "itertools 0.10.5",
 ]
 
 [[package]]
@@ -228,6 +344,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
 
 [[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,6 +357,50 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "cxx"
+version = "1.0.130"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23c042a0ba58aaff55299632834d1ea53ceff73d62373f62c9ae60890ad1b942"
+dependencies = [
+ "cc",
+ "cxxbridge-flags",
+ "cxxbridge-macro",
+ "link-cplusplus",
+]
+
+[[package]]
+name = "cxx-build"
+version = "1.0.130"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45dc1c88d0fdac57518a9b1f6c4f4fb2aca8f3c30c0d03d7d8518b47ca0bcea6"
+dependencies = [
+ "cc",
+ "codespan-reporting",
+ "proc-macro2",
+ "quote",
+ "scratch",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "cxxbridge-flags"
+version = "1.0.130"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa7ed7d30b289e2592cc55bc2ccd89803a63c913e008e6eb59f06cddf45bb52f"
+
+[[package]]
+name = "cxxbridge-macro"
+version = "1.0.130"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b8c465d22de46b851c04630a5fc749a26005b263632ed2e0d9cc81518ead78d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -399,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
 
 [[package]]
 name = "filetime"
@@ -489,6 +655,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,6 +675,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "iana-time-zone"
@@ -701,6 +883,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "is-terminal"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,7 +935,7 @@ dependencies = [
  "ndarray",
  "num-complex",
  "num-traits",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -764,15 +966,25 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
 
 [[package]]
 name = "libm"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+
+[[package]]
+name = "libmimalloc-sys"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23aa6811d3bd4deb8a84dde645f943476d13b248d818edcf8ce0b2f37f036b44"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "libredox"
@@ -783,6 +995,15 @@ dependencies = [
  "bitflags",
  "libc",
  "redox_syscall",
+]
+
+[[package]]
+name = "link-cplusplus"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d240c6f7e1ba3a28b0249f774e6a9dd0175054b52dfbb61b16eb8505c3785c9"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -818,6 +1039,15 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "mimalloc"
+version = "0.1.43"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68914350ae34959d83f732418d51e2427a794055d0b9529f48259ac07af65633"
+dependencies = [
+ "libmimalloc-sys",
+]
 
 [[package]]
 name = "miniz_oxide"
@@ -925,7 +1155,7 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -947,7 +1177,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tar",
- "thiserror",
+ "thiserror 1.0.69",
  "toml",
  "ureq",
  "url",
@@ -962,6 +1192,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
+name = "oorandom"
+version = "11.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
+
+[[package]]
 name = "openblas-build"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -971,7 +1207,7 @@ dependencies = [
  "flate2",
  "native-tls",
  "tar",
- "thiserror",
+ "thiserror 1.0.69",
  "ureq",
  "walkdir",
 ]
@@ -1043,6 +1279,8 @@ version = "0.1.0"
 dependencies = [
  "approx",
  "bon",
+ "criterion",
+ "mimalloc",
  "ndarray",
  "ndarray-rand",
  "petal-decomposition",
@@ -1051,8 +1289,9 @@ dependencies = [
  "rand",
  "rand_pcg",
  "rayon",
- "thiserror",
+ "thiserror 2.0.3",
  "tracing",
+ "usearch",
  "wide",
 ]
 
@@ -1069,7 +1308,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edbd757196da8f53844147edf32dee8029113f4467fdcba22809e6d6aa79e2a"
 dependencies = [
  "intel-mkl-src",
- "itertools",
+ "itertools 0.13.0",
  "lair",
  "lapack",
  "ndarray",
@@ -1080,7 +1319,7 @@ dependencies = [
  "rand",
  "rand_distr",
  "rand_pcg",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1094,6 +1333,34 @@ name = "pkg-config"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+
+[[package]]
+name = "plotters"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+dependencies = [
+ "num-traits",
+ "plotters-backend",
+ "plotters-svg",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "plotters-backend"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
+
+[[package]]
+name = "plotters-svg"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
+dependencies = [
+ "plotters-backend",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -1273,7 +1540,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1290,9 +1557,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1322,9 +1589,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.39"
+version = "0.38.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "375116bee2be9ed569afe2154ea6a99dfdffd257f533f187498c2a8f5feaf4ee"
+checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
 dependencies = [
  "bitflags",
  "errno",
@@ -1427,6 +1694,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scratch"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3cf7c11c38cb994f3d40e8a8cde3bbd1f72a435e4c49e85d6553d8312306152"
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1441,9 +1714,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
+checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -1451,18 +1724,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55c3193aca71c12ad7890f1785d2b73e1b9f63a0bbc353c08ef26fe03fc56b5"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.214"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1602,9 +1875,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -1614,19 +1887,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror"
-version = "1.0.68"
+name = "termcolor"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02dd99dc800bbb97186339685293e1cc5d9df1f8fae2d0aecd9ff1c77efea892"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
- "thiserror-impl",
+ "winapi-util",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+dependencies = [
+ "thiserror-impl 2.0.3",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.68"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7c61ec9a6f64d2793d8a45faba21efbe3ced62a886d44c36a009b2b519b4c7e"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1641,6 +1943,16 @@ checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
 dependencies = [
  "displaydoc",
  "zerovec",
+]
+
+[[package]]
+name = "tinytemplate"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1721,6 +2033,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
+name = "unicode-width"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+
+[[package]]
 name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1755,6 +2073,16 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+]
+
+[[package]]
+name = "usearch"
+version = "2.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df6435273b8a1f9eec88d7e3c003ed35f60fb6b777e38217734361c57e28c3f7"
+dependencies = [
+ "cxx",
+ "cxx-build",
 ]
 
 [[package]]
@@ -1860,6 +2188,16 @@ name = "wasm-bindgen-shared"
 version = "0.2.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "65fc09f10666a9f147042251e0dda9c18f166ff7de300607007e96bdebc1068d"
+
+[[package]]
+name = "web-sys"
+version = "0.3.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
 
 [[package]]
 name = "webpki-roots"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,12 +28,15 @@ petal-decomposition = "0.8"
 rand = { version = "0.8", features = ["small_rng"] }
 rand_pcg = "0.3"
 rayon = "1.10"
-thiserror = "1.0"
+thiserror = "2.0"
 tracing = "0.1"
+usearch = "2.16"
 wide = "0.7"
 
 [dev-dependencies]
 approx = "0.5"
+criterion = "0.5"
+mimalloc = "0.1"
 quickcheck = "1.0"
 quickcheck_macros = "1.0"
 
@@ -92,3 +95,13 @@ codegen-units = 1
 panic = "abort"
 debug = "full"
 opt-level = 3
+
+[profile.bench]
+lto = "fat"
+codegen-units = 1
+opt-level = 3
+
+[[bench]]
+name = "knn_bench"
+path = "benches/knn_bench.rs"
+harness = false

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ three types of point relationships:
 
 For details on the algorithm, see the [original paper](https://jmlr.org/papers/v22/20-1061.html).
 
+## Features
+
+- Fast approximate nearest neighbors for large datasets using USearch
+- SIMD-optimized distance calculations
+- Parallel processing with Rayon
+- Optional PCA initialization using various BLAS backends
+- Reproducible results with optional seeding
+
 ## Usage
 
 Basic usage with default parameters:
@@ -61,6 +69,7 @@ fn main() -> Result<()> {
         .num_iters((50, 50, 100))
         .mid_near_ratio(0.3)
         .far_pair_ratio(2.0)
+        .approx_threshold(8_000)  // Use approximate neighbors above this size
         .build();
 
     let (embedding, _) = fit_transform(data.view(), config)?;
@@ -70,7 +79,7 @@ fn main() -> Result<()> {
 
 Capturing intermediate states:
 
-```rust 
+```rust
 use anyhow::Result;
 use pacmap::Configuration;
 
@@ -103,6 +112,7 @@ For a standalone example, see the [pacmap-rs-example repository](https://github.
     2. Balanced weight phase
     3. Local structure focus phase
 - `snapshots`: Optional vector of iterations at which to save embedding states
+- `approx_threshold`: Number of samples above which to use approximate nearest neighbors (default: 8,000)
 
 ### Pair Sampling Parameters
 
@@ -143,8 +153,7 @@ information about BLAS/LAPACK backend configuration and performance consideratio
 This implementation currently:
 
 - Only supports Euclidean distances
-- Uses exact rather than approximate nearest neighbors
-- Has not been optimized for very large datasets
+- Does not support incremental transform
 
 ## References
 

--- a/benches/knn_bench.rs
+++ b/benches/knn_bench.rs
@@ -1,3 +1,9 @@
+//! Benchmarks for k-nearest neighbors implementations in PaCMAP.
+//!
+//! Compares performance of exact and approximate KNN algorithms across
+//! different dataset sizes and dimensions. Uses criterion for structured
+//! benchmarking and MiMalloc for optimized memory allocation.
+
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use mimalloc::MiMalloc;
 use ndarray::Array2;
@@ -6,30 +12,36 @@ use rand::prelude::*;
 use rand::SeedableRng;
 use rand_pcg::Pcg64Mcg;
 
+/// Use MiMalloc as the global allocator for optimal memory performance
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 
+/// Benchmarks exact vs approximate k-nearest neighbors algorithms.
+///
+/// Measures performance across multiple dataset sizes, keeping dimension and k
+/// fixed. Uses reproducible random data generated with a fixed seed.
+///
+/// # Arguments
+/// * `c` - Criterion benchmark configuration
 fn knn_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("KNN Benchmark");
     group.sample_size(10);
 
-    // Data sizes to test
     let sizes = vec![500, 1000, 5000, 10000, 20000, 50000, 70000];
     let k = 60;
     let dim = 784;
 
-    // Fixed seed for reproducibility
     let seed = [0u8; 16];
     let mut rng = Pcg64Mcg::from_seed(seed);
 
-    // Generate random data outside the benchmark loops
+    // Generate all datasets upfront to avoid including data generation in timing
     let datasets: Vec<(usize, Array2<f32>)> = sizes
         .iter()
         .map(|&size| (size, generate_random_data(size, dim, &mut rng)))
         .collect();
 
     for (size, data) in datasets {
-        // Benchmark the exact method
+        // Benchmark exact KNN implementation
         group.bench_with_input(BenchmarkId::new("Exact", size), &data, |b, data| {
             b.iter(|| {
                 let (neighbors, distances) = find_k_nearest_neighbors(data.view(), k);
@@ -37,7 +49,7 @@ fn knn_benchmark(c: &mut Criterion) {
             });
         });
 
-        // Benchmark the approximate method
+        // Benchmark approximate KNN implementation
         group.bench_with_input(BenchmarkId::new("Approximate", size), &data, |b, data| {
             b.iter(|| match find_k_nearest_neighbors_approx(data.view(), k) {
                 Ok((neighbors, distances)) => {
@@ -53,8 +65,18 @@ fn knn_benchmark(c: &mut Criterion) {
     group.finish();
 }
 
+/// Generates random test data for KNN benchmarking.
+///
+/// Creates a matrix of uniformly distributed random floats.
+///
+/// # Arguments
+/// * `n` - Number of samples/rows
+/// * `dim` - Number of features/columns
+/// * `rng` - Random number generator
+///
+/// # Returns
+/// An n × dim matrix of random floats
 fn generate_random_data(n: usize, dim: usize, rng: &mut impl Rng) -> Array2<f32> {
-    // Generate an Array2 of shape (n, dim) filled with random floats
     Array2::from_shape_fn((n, dim), |_| rng.gen())
 }
 

--- a/benches/knn_bench.rs
+++ b/benches/knn_bench.rs
@@ -1,0 +1,62 @@
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use mimalloc::MiMalloc;
+use ndarray::Array2;
+use pacmap::knn::{find_k_nearest_neighbors, find_k_nearest_neighbors_approx};
+use rand::prelude::*;
+use rand::SeedableRng;
+use rand_pcg::Pcg64Mcg;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
+
+fn knn_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("KNN Benchmark");
+    group.sample_size(10);
+
+    // Data sizes to test
+    let sizes = vec![500, 1000, 5000, 10000, 20000, 50000, 70000];
+    let k = 60;
+    let dim = 784;
+
+    // Fixed seed for reproducibility
+    let seed = [0u8; 16];
+    let mut rng = Pcg64Mcg::from_seed(seed);
+
+    // Generate random data outside the benchmark loops
+    let datasets: Vec<(usize, Array2<f32>)> = sizes
+        .iter()
+        .map(|&size| (size, generate_random_data(size, dim, &mut rng)))
+        .collect();
+
+    for (size, data) in datasets {
+        // Benchmark the exact method
+        group.bench_with_input(BenchmarkId::new("Exact", size), &data, |b, data| {
+            b.iter(|| {
+                let (neighbors, distances) = find_k_nearest_neighbors(data.view(), k);
+                black_box((neighbors, distances));
+            });
+        });
+
+        // Benchmark the approximate method
+        group.bench_with_input(BenchmarkId::new("Approximate", size), &data, |b, data| {
+            b.iter(|| match find_k_nearest_neighbors_approx(data.view(), k) {
+                Ok((neighbors, distances)) => {
+                    black_box((neighbors, distances));
+                }
+                Err(err) => {
+                    panic!("Error during approximate KNN: {:?}", err);
+                }
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn generate_random_data(n: usize, dim: usize, rng: &mut impl Rng) -> Array2<f32> {
+    // Generate an Array2 of shape (n, dim) filled with random floats
+    Array2::from_shape_fn((n, dim), |_| rng.gen())
+}
+
+criterion_group!(benches, knn_benchmark);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -75,6 +75,8 @@
 //!   (100, 100, 250))
 //! - `snapshots`: Optional vector of iterations at which to save embedding
 //!   states
+//! - `approx_threshold`: Number of points above which approximate neighbor
+//!   search is used
 //!
 //! Pair sampling parameters:
 //! - `mid_near_ratio`: Ratio of mid-near to nearest neighbor pairs (default:

--- a/src/neighbors.rs
+++ b/src/neighbors.rs
@@ -1,13 +1,21 @@
-//! Manages pair generation for `PaCMAP` dimensionality reduction.
+//! Manages sampling of point pairs for `PaCMAP` dimensionality reduction.
 //!
-//! This module generates point pairs that control how structure is preserved:
-//! - Nearest neighbor pairs capture local neighborhoods and distances
-//! - Mid-near pairs maintain relationships between moderately distant points
-//! - Far pairs prevent the embedding from collapsing by keeping distant points
-//!   separated
+//! This module generates three key types of point pairs that control how
+//! structure is preserved during dimension reduction:
 //!
-//! Supports both deterministic and non-deterministic sampling with optional
-//! random seeds.
+//! - Nearest neighbor pairs preserve local neighborhoods and distances by
+//!   connecting each point to its closest neighbors
+//!
+//! - Mid-near pairs maintain relationships between moderately distant points to
+//!   capture intermediate structure and prevent overfitting to local
+//!   neighborhoods
+//!
+//! - Far pairs prevent the embedding from collapsing by introducing repulsive
+//!   forces between distant points
+//!
+//! The module supports both deterministic (seeded) and non-deterministic pair
+//! sampling. For larger datasets, it can use approximate nearest neighbor
+//! search to improve performance.
 
 use crate::distance::scale_dist;
 use crate::knn::{find_k_nearest_neighbors, find_k_nearest_neighbors_approx, KnnError};
@@ -19,48 +27,55 @@ use crate::Pairs;
 use ndarray::{s, Array1, Array2, ArrayView2, Axis};
 use std::cmp::min;
 
-/// Builds the complete set of point pairs needed for `PaCMAP` optimization.
+/// Generates the complete set of point pairs needed for `PaCMAP` optimization.
 ///
-/// Creates all three pair types through a multistep process:
-/// 1. Finds k-nearest neighbors with padding for robustness
+/// Creates all three pair types (nearest neighbor, mid-near, far) through a
+/// multi-step process:
+///
+/// 1. Finds k-nearest neighbors with padding for robust pair selection
 /// 2. Computes scaling factors from moderately distant neighbors (indices 3-5)
-/// 3. Applies distance scaling
+/// 3. Applies distance scaling to normalize neighborhood sizes
 /// 4. Samples neighbor pairs based on scaled distances
 /// 5. Generates mid-near and far pairs either deterministically or randomly
 ///
 /// # Arguments
-/// * `x` - Input data as an n × d matrix
-/// * `n_neighbors` - Number of nearest neighbors per point
-/// * `n_mn` - Number of mid-near pairs per point
-/// * `n_fp` - Number of far pairs per point
-/// * `random_state` - Optional seed for deterministic sampling
+/// * `x` - Input data as an n × d matrix where each row is a point
+/// * `n_neighbors` - Number of nearest neighbors to find per point
+/// * `n_mn` - Number of mid-near pairs to generate per point
+/// * `n_fp` - Number of far pairs to generate per point
+/// * `random_state` - Optional seed for deterministic pair sampling
+/// * `approx_threshold` - Row count threshold for switching to approximate
+///   neighbor search
 ///
 /// # Returns
-/// A `Pairs` struct containing arrays of indices for each pair type
+/// A `Pairs` struct containing the neighbor, mid-near, and far pair indices
 ///
 /// # Errors
-/// Returns `KnnError` if the k-nearest neighbors search fails
+/// Returns `KnnError` if k-nearest neighbor search fails due to index
+/// construction or memory allocation issues
 pub fn generate_pairs(
     x: ArrayView2<f32>,
     n_neighbors: usize,
     n_mn: usize,
     n_fp: usize,
     random_state: Option<u64>,
+    approx_threshold: usize,
 ) -> Result<Pairs, KnnError> {
     let n = x.nrows();
 
-    // Add padding neighbors for robustness in selecting final pairs
+    // Add padding neighbors for robust pair selection
     let n_neighbors_extra = (n_neighbors + 50).min(n - 1);
     let n_neighbors = n_neighbors.min(n - 1);
 
     // Use exact neighbors for small datasets, approximate for large ones
-    let (neighbors, knn_distances) = if n < 8_000 {
+    let (neighbors, knn_distances) = if n < approx_threshold {
         find_k_nearest_neighbors(x, n_neighbors_extra)
     } else {
         find_k_nearest_neighbors_approx(x, n_neighbors_extra)?
     };
 
-    // Scale distances using moderately distant neighbors for robustness
+    // Scale distances using moderately distant neighbors (indices 3-5)
+    // for robust neighborhood size estimation
     let start = min(3, knn_distances.ncols().saturating_sub(1));
     let end = min(6, knn_distances.ncols());
     let sig = knn_distances
@@ -73,7 +88,7 @@ pub fn generate_pairs(
     let pair_neighbors =
         sample_neighbors_pair(x.view(), scaled_dist.view(), neighbors_view, n_neighbors);
 
-    // Generate remaining pairs either deterministically or randomly
+    // Generate mid-near and far pairs either deterministically or randomly
     let (pair_mn, pair_fp) = match random_state {
         Some(seed) => (
             sample_mn_pair_deterministic(x.view(), n_mn, seed),
@@ -94,13 +109,12 @@ pub fn generate_pairs(
 
 /// Generates mid-near and far pairs from pre-computed nearest neighbors.
 ///
-/// Used when nearest neighbor pairs have already been computed, to avoid
-/// redundant distance calculations while still generating the other required
-/// pair types.
+/// Efficiently generates additional pairs when nearest neighbors have already
+/// been computed, avoiding redundant distance calculations.
 ///
 /// # Arguments
-/// * `x` - Input data as an n × d matrix
-/// * `n_neighbors` - Number of nearest neighbors used to generate input pairs
+/// * `x` - Input data as an n × d matrix where each row is a point
+/// * `n_neighbors` - Number of nearest neighbors used in input pairs
 /// * `n_mn` - Number of mid-near pairs to generate per point
 /// * `n_fp` - Number of far pairs to generate per point
 /// * `pair_neighbors` - Pre-computed nearest neighbor pair indices
@@ -108,8 +122,8 @@ pub fn generate_pairs(
 ///
 /// # Returns
 /// A tuple containing:
-/// - Mid-near pair indices as an (n*`n_mn`) × 2 array
-/// - Far pair indices as an (n*`n_fp`) × 2 array
+/// - Mid-near pair indices as an (n × `n_mn`) × 2 array
+/// - Far pair indices as an (n × `n_fp`) × 2 array
 pub fn generate_pair_no_neighbors(
     x: ArrayView2<f32>,
     n_neighbors: usize,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -52,6 +52,7 @@ fn test_fit_transform() {
             learning_rate: 1.0,
             num_iters: (100, 100, 250),
             snapshots: Some(vec![100, 200, 300]),
+            approx_threshold: 8_000,
         },
         // Random initialization with seed
         Configuration {
@@ -65,6 +66,7 @@ fn test_fit_transform() {
             learning_rate: 0.8,
             num_iters: (50, 50, 100),
             snapshots: None,
+            approx_threshold: 8_000,
         },
     ];
 


### PR DESCRIPTION
This PR adds support for approximate k-nearest neighbor search to improve performance on large datasets. Key changes include:

- Integrates the USearch library for fast approximate neighbor search using spatial indexing
- Adds configurable threshold (default 8000 points) above which approximate search is used
- Implements parallel index construction and search using rayon
- Updates documentation with new feature details and implementation notes
- Adds benchmarks comparing exact vs approximate KNN performance
- Updates error handling to include index construction and memory allocation errors

Benchmark Results (Apple M2 Max):
| Data Size | Exact (ms) | Approximate (ms) | Speedup |
|-----------|------------|------------------|---------|
| 500       | 2.6        | 14.7            | 0.18x   |
| 1,000     | 8.3        | 37.9            | 0.22x   |
| 5,000     | 182.0      | 326.1           | 0.56x   |
| 10,000    | 861.5      | 763.8           | 1.13x   |
| 20,000    | 4,006.0    | 1,905.0         | 2.10x   |
| 50,000    | 29,519.0   | 6,654.4         | 4.44x   |

Benchmark parameters:
- k = 60 nearest neighbors
- dim = 784 features
- Random uniform data in [0,1]
- 10 samples per size
- Using MiMalloc allocator