### PR TITLE
fix: downgrade USearch to compile on older OSes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,14 @@ env:
 
 jobs:
   title:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Run Commit Lint
         uses: opensource-nepal/commitlint@v1
 
   check:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Install BLAS
@@ -50,7 +50,7 @@ jobs:
           args: --features openblas-system -- -D warnings
 
   test:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Install BLAS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   release-please:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     outputs:
       release_created: ${{ steps.release.outputs.release_created }}
       tag_name: ${{ steps.release.outputs.tag_name }}
@@ -26,7 +26,7 @@ jobs:
   publish:
     needs: release-please
     if: ${{ needs.release-please.outputs.release_created }}
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "2.3.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97493a391b4b18ee918675fb8663e53646fd09321c58b46afa04e8ce2499c869"
+checksum = "32649b2d94d4dae1084cffd2ce1a778165e887497e4d1d55cd3976839f76194e"
 dependencies = [
  "bon-macros",
  "rustversion",
@@ -104,14 +104,16 @@ dependencies = [
 
 [[package]]
 name = "bon-macros"
-version = "2.3.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2af3eac944c12cdf4423eab70d310da0a8e5851a18ffb192c0a5e3f7ae1663"
+checksum = "13823053b3090fb2a35940608b0ff4c9254eb97651a971cf49fd84f8604c2591"
 dependencies = [
  "darling",
  "ident_case",
+ "prettyplease",
  "proc-macro2",
  "quote",
+ "rustversion",
  "syn 2.0.87",
 ]
 
@@ -1384,6 +1386,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.87",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ netlib-static = ["petal-decomposition/netlib-static", "ndarray/blas"]
 netlib-system = ["petal-decomposition/netlib-system", "ndarray/blas"]
 
 [dependencies]
-bon = "2.3"
+bon = "3.0"
 ndarray = { version = "0.16", features = ["rayon"] }
 ndarray-rand = "0.15"
 petal-decomposition = "0.8"
@@ -30,7 +30,7 @@ rand_pcg = "0.3"
 rayon = "1.10"
 thiserror = "2.0"
 tracing = "0.1"
-usearch = "2.16"
+usearch = "2.15.3"
 wide = "0.7"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -31,33 +31,6 @@ For details on the algorithm, see the [original paper](https://jmlr.org/papers/v
 - Optional PCA initialization using various BLAS backends
 - Reproducible results with optional seeding
 
-## System Requirements
-
-### GCC Version
-
-This crate uses USearch for efficient nearest neighbor search, which requires GCC 13+ to build and a recent glibc to
-run. You may need to install a newer GCC version on your system.
-
-For Ubuntu, upgrade to 24.04. On Debian:
-
-```bash
-# Add testing repo
-echo "deb http://deb.debian.org/debian testing main" | sudo tee /etc/apt/sources.list.d/testing.list
-sudo apt-get update
-
-# Install GCC 13
-sudo apt-get install gcc-13 g++-13
-
-# Set as default compiler
-sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-13 60 \
-  --slave /usr/bin/g++ g++ /usr/bin/g++-13 \
-  --slave /usr/bin/gcov gcov /usr/bin/gcov-13
-
-# Set environment variables
-export CC=/usr/bin/gcc-13
-export CXX=/usr/bin/g++-13
-```
-
 ## Usage
 
 Basic usage with default parameters:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,15 +26,6 @@
 //! - Multiple initialization options including PCA and random seeding
 //! - Optional snapshot capture of intermediate states
 //!
-//! ## System Requirements
-//!
-//! This crate uses `USearch` for efficient nearest neighbor search, which requires:
-//! - GCC 13+ to build
-//! - Recent glibc for runtime
-//!
-//! You may need to install a newer GCC version on your system. See the README for
-//! detailed installation instructions.
-//!
 //! ## Examples
 //!
 //! Basic usage with default parameters:


### PR DESCRIPTION
The latest USearch version breaks builds on several platforms because it requires GCC 13+. Remove this requirement