### PR TITLE
fix: make simsimd a feature flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
           args: --features openblas-system
 
   dependencies:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Install BLAS

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ readme = "README.md"
 
 [features]
 default = []
+simsimd = ["usearch/simsimd"]
 intel-mkl-static = ["petal-decomposition/intel-mkl-static", "ndarray/blas"]
 intel-mkl-system = ["petal-decomposition/intel-mkl-system", "ndarray/blas"]
 openblas-static = ["petal-decomposition/openblas-static", "ndarray/blas"]
@@ -30,7 +31,7 @@ rand_pcg = "0.3"
 rayon = "1.10"
 thiserror = "2.0"
 tracing = "0.1"
-usearch = "2.15.3"
+usearch = { version = "2.16", default-features = false, features = ["fp16lib"] }
 wide = "0.7"
 
 [dev-dependencies]

--- a/README.md
+++ b/README.md
@@ -128,26 +128,34 @@ For a standalone example, see the [pacmap-rs-example repository](https://github.
 - `PairConfiguration::NeighborsProvided { pair_neighbors }` - Use provided nearest neighbors, generate remaining pairs
 - `PairConfiguration::AllProvided { pair_neighbors, pair_mn, pair_fp }` - Use all provided pairs
 
-## BLAS/LAPACK Requirements
+## Feature Flags
 
-This crate requires a BLAS/LAPACK backend for PCA. Because BLAS/LAPACK implementations are complex system dependencies,
-you must explicitly choose one when building on non-macOS platforms:
+### BLAS/LAPACK Backends
 
-- `intel-mkl-static` or `intel-mkl-system` for Intel MKL
-- `netlib-static` or `netlib-system` for Netlib
-- `openblas-static` or `openblas-system` for OpenBLAS
+Only one BLAS/LAPACK backend feature should be enabled at a time.
+These are required for PCA operations except on macOS which uses Accelerate by default.
+
+- `intel-mkl-static` - Static linking with Intel MKL
+- `intel-mkl-system` - Dynamic linking with system Intel MKL
+- `openblas-static` - Static linking with OpenBLAS
+- `openblas-system` - Dynamic linking with system OpenBLAS
+- `netlib-static` - Static linking with Netlib
+- `netlib-system` - Dynamic linking with system Netlib
 
 For example:
 
 ```toml
 [dependencies]
-pacmap = { version = "0.1", features = ["openblas-static"] }
+pacmap = { version = "0.2", features = ["openblas-static"] }
 ```
 
-**Note:** On macOS, the Accelerate Framework is used by default, so these features are not needed.
-
 See [ndarray-linalg's documentation](https://github.com/rust-ndarray/ndarray-linalg#backend-features) for detailed
-information about BLAS/LAPACK backend configuration and performance considerations.
+information about BLAS/LAPACK configuration and performance considerations.
+
+### Performance Features
+
+- `simsimd` - Enable SIMD optimizations in USearch for faster approximate nearest neighbor search.
+  Requires GCC 13+ for compilation and a recent glibc at runtime.
 
 ## Limitations
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,30 @@
 //! - `override_neighbors`: Optional fixed neighbor count override
 //! - `seed`: Optional random seed for reproducible sampling
 //!
+//! ## Feature Flags
+//!
+//! ### BLAS/LAPACK Backends
+//!
+//! Only one BLAS/LAPACK backend feature should be enabled at a time. These are
+//! required for PCA operations except on macOS which uses Accelerate by
+//! default.
+//!
+//! - `intel-mkl-static` - Static linking with Intel MKL
+//! - `intel-mkl-system` - Dynamic linking with system Intel MKL
+//! - `openblas-static` - Static linking with `OpenBLAS`
+//! - `openblas-system` - Dynamic linking with system `OpenBLAS`
+//! - `netlib-static` - Static linking with Netlib
+//! - `netlib-system` - Dynamic linking with system Netlib
+//!
+//! For more details on BLAS/LAPACK configuration, see the [ndarray-linalg
+//! documentation](https://github.com/rust-ndarray/ndarray-linalg#backend-features).
+//!
+//! ### Performance Features
+//!
+//! - `simsimd` - Enable SIMD optimizations in `USearch` for faster approximate
+//!   nearest neighbor search. Requires GCC 13+ for compilation and a recent
+//!   glibc at runtime.
+//!
 //! ## Implementation Notes
 //!
 //! - Supports both exact and approximate nearest neighbor search


### PR DESCRIPTION
Addresses CI and docs.rs build failures by:
- Making simsimd an opt-in feature flag to avoid GCC 13+ requirement
- Updating usearch to 2.16 without the simsimd feature
- Expanding feature flag documentation

The simsimd feature now requires explicit opt-in since it needs GCC 13+ and recent glibc, which aren't available in common CI environments like docs.rs and older Ubuntu releases.