### PR TITLE
fix: skip zero pairs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,9 +94,9 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32649b2d94d4dae1084cffd2ce1a778165e887497e4d1d55cd3976839f76194e"
+checksum = "65b4408cb90c75f462c2428254f2a687c399d1feb22ebdc7511889d07be6cab0"
 dependencies = [
  "bon-macros",
  "rustversion",
@@ -104,9 +104,9 @@ dependencies = [
 
 [[package]]
 name = "bon-macros"
-version = "3.0.0"
+version = "3.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13823053b3090fb2a35940608b0ff4c9254eb97651a971cf49fd84f8604c2591"
+checksum = "bfc5494814aa273050386f95a7d1fa36dcc677fc796bffe54f34659678335bc0"
 dependencies = [
  "darling",
  "ident_case",
@@ -1756,9 +1756,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.132"
+version = "1.0.133"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d726bfaff4b320266d395898905d0eba0345aae23b54aee3a737e260fd46db03"
+checksum = "c7fceb2473b9166b2294ef05efcb65a3db80803f0b03ef86a5fc88a2b85ee377"
 dependencies = [
  "itoa",
  "memchr",

--- a/src/gradient.rs
+++ b/src/gradient.rs
@@ -114,6 +114,10 @@ fn process_pairs(
         let i = pair_row[0] as usize;
         let j = pair_row[1] as usize;
 
+        if i == j {
+            continue;
+        }
+
         // Calculate squared distance between points
         let mut d_ij = 1.0f32;
         for d in 0..dim {


### PR DESCRIPTION
Pairs may be left zero if there aren't enough neighbors to sample. Exclude those zero points in the gradient calculation.